### PR TITLE
Fixed reference to sample app

### DIFF
--- a/local_agents/rag/README.md
+++ b/local_agents/rag/README.md
@@ -28,7 +28,7 @@ on the `Chain` interface [Java API](https://github.com/google-ai-edge/ai-edge-ap
 
 ## Demos
 
-Try our [sample app](https://github.com/google-ai-edge/ai-edge-apis/tree/main/examples/local_agents/rag)
+Try our [sample app](https://github.com/google-ai-edge/ai-edge-apis//tree/main/examples/rag/android)
 for a quick demo.
 
 ## Guide


### PR DESCRIPTION
The original reference returns a "404 - page not found". Fixed it with what appears to be the right reference for the RAG Android app