### PR TITLE
Fix button state of second page of FC demo app.

### DIFF
--- a/examples/function_calling/healthcare_form_demo/app/src/main/java/com/google/sample/fcdemo/ui/screens/Fieldset2Screen.kt
+++ b/examples/function_calling/healthcare_form_demo/app/src/main/java/com/google/sample/fcdemo/ui/screens/Fieldset2Screen.kt
@@ -62,8 +62,8 @@ fun Fieldset2Screen(
     }
 
     Fieldset2Content(
-        sex = sex.toString(),
-        maritalStatus = maritalStatus.toString(),
+        sex = sex?.toString(),
+        maritalStatus = maritalStatus?.toString(),
         onSexChanged = onSexChanged,
         onMaritalStatusChanged = onMaritalStatusChanged,
         listeningState = listeningState,

--- a/examples/function_calling/healthcare_form_demo/app/src/main/java/com/google/sample/fcdemo/ui/screens/Fieldset3Screen.kt
+++ b/examples/function_calling/healthcare_form_demo/app/src/main/java/com/google/sample/fcdemo/ui/screens/Fieldset3Screen.kt
@@ -91,8 +91,7 @@ internal fun Fieldset3Content(
     onHomePressed: () -> Unit,
     snackbarHostState: SnackbarHostState,
 ) {
-    // it is possible the patient has none of the possible conditions
-    val fieldsetIsCompleteAndValid = true
+    val fieldsetIsCompleteAndValid = medicalConditions.any { it.value }
 
     Scaffold(
         topBar = {


### PR DESCRIPTION
When sex and marital status have not been entered, the bottom of the screen shows microphone button instead of the "Edit" button.

Also require at least one medical condition to be selected before continuing.

This improves the user flow the app by making the microphone button appear at the start of every page.