### PR TITLE
Adding local loading functionality for LiteRT LLM pipelines.

### DIFF
--- a/litert_tools/litert_tools/pipeline/pipeline.py
+++ b/litert_tools/litert_tools/pipeline/pipeline.py
@@ -561,6 +561,7 @@ class LiteRTLlmPipelineLoader(LlmPipelineLoader):
             The LiteRT LLM pipeline.
         """
         logging.info("Loading LiteRTLlmPipeline from: %s", file_path)
+
         try:
             file_path = os.path.abspath(file_path)
             if file_path and file_path.endswith(".task"):
@@ -572,12 +573,14 @@ class LiteRTLlmPipelineLoader(LlmPipelineLoader):
                 raw_tokenizer.Load(tokenizer_path)
 
                 prompt_template = file_processor.get_prompt_template()
-
-            elif tokenizer_location and self._uses_hugging_face():
+                
+            elif tokenizer_location:
+                
                 raw_tokenizer = transformers.AutoTokenizer.from_pretrained(
                     tokenizer_location
                 )
                 prompt_template = None
+                model_path = file_path
         except Exception as e:
             logging.error(
                 "Failed to obtain tokenizer from %s: %s",


### PR DESCRIPTION
This commit introduces a new `local_load` function at the top level and within `LiteRTLlmPipelineLoader`. This allows users to load an LLM pipeline directly from a local `.task` file, providing an alternative to downloading models from Hugging Face.
The changes include:
* **`local_load` function (top-level):** Provides a simple entry point for loading local `.task` files.
* **`LiteRTLlmPipelineLoader.local_load` method:** Implements the core logic for processing a local `.task` file, extracting the TFLite model and tokenizer, and initializing the LiteRT LLM pipeline.
* **Docstring and comment updates:** Improved clarity and accuracy for the new `local_load` functions, detailing their purpose, arguments, and return values.

This enhancement simplifies the process of using locally stored LiteRT LLM models.